### PR TITLE
Fixes*  "npm not found" and random plugin-not-running issues

### DIFF
--- a/post-release
+++ b/post-release
@@ -3,12 +3,17 @@
 APP="$1"; IMAGE="dokku/$APP"
 echo "-----> Building Node app ..."
 COMMAND=$(cat <<EOF
-cd "\$DOKKU_ROOT/\$APP" &&
-server/prepare_dist &&
+cd "/app" &&
+new_path="\$(find / -name npm | tail -1 | xargs -I % sh -c "dirname %")" &&
+PATH="\$PATH:\$new_path" &&
+PATH="\$PATH:\$(npm bin)" &&
+npm install grunt &&
+npm install grunt-cli &&
+npm install bower &&
 npm update &&
-bower install &&
-bower update &&
-grunt build
+bower --allow-root install &&
+bower --allow-root update &&
+grunt build --force
 EOF
 )
 


### PR DESCRIPTION
fixes\* a few issues I was having, namely due to `npm` not being in `$PATH`.

also insures that `grunt` + `grunt-cli` as well as `bower` are _actually_ installed
before calling them to do post-deploy builds.

It may seem dirty to add the `--allow-root` and `--force` flags; here's why I did:
- sometimes (especially when debugging on DO droplets) users will be on the
  root account (I'm not saying they should be!); without this flag, bower will
  refuse to run. I don't see any harm in allowing it for 'git-push' style
  builds anyways...
- because I can't find any not-ridiculous way to re-push with "force enabled"
  short of issuing sketchy direct-commands to the container.

*fixes == command-line hacks from a guy that started using docker and dokku _today_. There are probably better ways to do this. I just need bower and grunt to build when I push and this accomplishes that (for me). 

**If you are still having one of these issues, comment here or message me with more details** (https://github.com/thrashr888/dokku-bower-grunt-build-plugin/issues/3 and https://github.com/thrashr888/dokku-bower-grunt-build-plugin/issues/4).
